### PR TITLE
Fix env based activation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'test-selectors',
 
   included: function() {
-    if (this.app.environment !== 'development' && this.app.environment !== 'test') {
+    if (this.app.env !== 'development' && this.app.env !== 'test') {
       this.app.registry.add('htmlbars-ast-plugin', {
         name: 'strip-test-selectors',
         plugin: StringTestSelectorsTransform


### PR DESCRIPTION
The property that holds the environment name is actually `env`, not `environment`.