### PR TITLE
Add test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,33 @@ delivered__:
 </article>
 ```
 
+## Testing
+
+Ember Test Selectors comes with a test helper that can be used in acceptance & integration tests:
+
+* `testSelector('post-title')`: Returns a selector `[data-test-post-title]`
+* `testSelector('resource-id', '2')`: Returns a selector `[data-test-resource-id="2"]`
+
+The test helpers can be imported from the helpers/ember-test-selectors module in the application's namespace:
+
+```javascript
+import testSelector from '<app-name>/tests/helpers/ember-test-selectors';
+```
+
+### Acceptance Test Usage
+
+```javascript
+find(testSelector('post-title')) // => find('[data-test-post-title]')
+find(testSelector('selector', 'post-title')) // => find('[data-test-selector="post-title"]')
+```
+
+### Integration Test Usage
+
+```javascript
+this.$(testSelector('post-title')).click() // => this.$('[data-test-post-title]').click()
+this.$(testSelector('selector', 'post-title')).click() // => this.$('[data-test-selector="post-title"]').click()
+```
+
 ## License
 
 ember-test-selectors is developed by and &copy;

--- a/test-support/helpers/ember-test-selectors.js
+++ b/test-support/helpers/ember-test-selectors.js
@@ -1,0 +1,9 @@
+export default function testSelector(key, value) {
+  let selector;
+  if (value) {
+    selector = `[data-test-${key}="${value}"]`;
+  } else {
+    selector = `[data-test-${key}]`;
+  }
+  return selector;
+};

--- a/tests/unit/test-support/helpers-test.js
+++ b/tests/unit/test-support/helpers-test.js
@@ -1,0 +1,12 @@
+import testSelector from 'dummy/tests/helpers/ember-test-selectors';
+import { module, test } from 'qunit';
+
+module('test-support helpers');
+
+test('testSelector with a value', function(assert) {
+  assert.equal(testSelector('selector', 'welcome-text'), '[data-test-selector="welcome-text"]');
+});
+
+test('testSelector without a value', function(assert) {
+  assert.equal(testSelector('selector'), '[data-test-selector]');
+});


### PR DESCRIPTION
Hey – thanks for the great addon!

I took a look at #8. The solution is very similar but not exactly as suggested in the last comment

- The helper converts to `[data-test-selector]` not `*[data-test-selector]`
- The helper usage is also `testSelector('post-title')` not `testSelector('data-test-post-title')` as in the last comment (but I think that was your original intention anyhow)

I also removed the `StripTestSelectorsTransform` from ember-cli-build so the tests would have the selectors.

I based the readme additions off ember-simple-auth test helper section.

I'd be happy to make any changes :)