### PR TITLE
Check `value` argument for absence, not falsiness.

### DIFF
--- a/test-support/helpers/ember-test-selectors.js
+++ b/test-support/helpers/ember-test-selectors.js
@@ -1,6 +1,12 @@
+import Ember from 'ember';
+
+const {
+  isNone
+} = Ember;
+
 export default function testSelector(key, value) {
   let selector;
-  if (value) {
+  if (!isNone(value)) {
     selector = `[data-test-${key}="${value}"]`;
   } else {
     selector = `[data-test-${key}]`;

--- a/tests/unit/test-support/helpers-test.js
+++ b/tests/unit/test-support/helpers-test.js
@@ -5,6 +5,7 @@ module('test-support helpers');
 
 test('expands a selector name and attribute value corretly', function(assert) {
   assert.equal(testSelector('selector', 'welcome-text'), '[data-test-selector="welcome-text"]');
+  assert.equal(testSelector('selector', 0), '[data-test-selector="0"]');
 });
 
 test('expands a selector name without attribute value corretly', function(assert) {


### PR DESCRIPTION
Fixes #23 by using `Ember.isNone()` instead of falsiness on the second argument to the helper.