### PR TITLE
Simplify testSelector() function

### DIFF
--- a/test-support/helpers/ember-test-selectors.js
+++ b/test-support/helpers/ember-test-selectors.js
@@ -5,11 +5,5 @@ const {
 } = Ember;
 
 export default function testSelector(key, value) {
-  let selector;
-  if (!isNone(value)) {
-    selector = `[data-test-${key}="${value}"]`;
-  } else {
-    selector = `[data-test-${key}]`;
-  }
-  return selector;
-};
+  return isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;
+}


### PR DESCRIPTION
Ternary operators are often considered harder to read, but in this case I think it simplifies the logic quite a bit.