### PR TITLE
CI: Run tests for all minor Ember versions again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,6 @@ cache:
   directories:
     - node_modules
 
-env:
-  - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
 before_install:
   - npm config set spin false
   - npm install -g bower
@@ -35,7 +23,7 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - npm test -- --skip-cleanup
   - npm run mocha
 
 notifications:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
 module.exports = {
+  useVersionCompatibility: true,
   scenarios: [
     {
       name: 'ember-1.13',
@@ -9,17 +10,6 @@ module.exports = {
         },
         resolutions: {
           'ember': '~1.13.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
         }
       }
     },


### PR DESCRIPTION
This was an unintended change in #29 