### PR TITLE
Run tests with and without stripping test selectors

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
 module.exports = {
+  command: 'npm run test:both',
   useVersionCompatibility: true,
   scenarios: [
     {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,22 +1,12 @@
 /*jshint node:true*/
 /* global require, module */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-var StripTestSelectorsTransform = require('./strip-test-selectors');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     'ember-test-selectors': {
       environments: ['test']
     }
-  });
-
-  // add the StripTestSelectorsTransform to the registry, so the dummy app has
-  // it added in the HTMLBars build pipeline: all data-test-* attributes are
-  // therefore stripped
-  app.registry.add('htmlbars-ast-plugin', {
-    name: 'strip-test-selectors',
-    plugin: StripTestSelectorsTransform,
-    baseDir: function() { return __dirname; }
   });
 
   return app.toTree();

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,9 +3,12 @@
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
+  var stripTestSelectors = process.env['STRIP_TEST_SELECTORS'];
+  var environments = stripTestSelectors ? ['test'] : ['production'];
+
   var app = new EmberAddon(defaults, {
     'ember-test-selectors': {
-      environments: ['test']
+      environments: environments
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "build": "ember build",
     "lint": "eslint config test-support tests *.js",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "test:both": "npm run test:keep && npm run test:strip",
+    "test:keep": "ember test",
+    "test:strip": "STRIP_TEST_SELECTORS=true ember test"
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,7 +20,9 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
+
+    stripTestSelectors: process.env['STRIP_TEST_SELECTORS']
   };
 
   if (environment === 'development') {

--- a/tests/integration/strip-data-test-attributes-test.js
+++ b/tests/integration/strip-data-test-attributes-test.js
@@ -1,43 +1,58 @@
 import { moduleForComponent, test } from "ember-qunit";
 import hbs from "htmlbars-inline-precompile";
 
+import config from 'dummy/config/environment';
+
 moduleForComponent('data-test', 'StripTestSelectorsTransform plugin', {
   integration: true
 });
 
-test('it strips data-test-* attributes', function(assert) {
-  this.render(hbs`<span data-test-id="my-id" ></span>`);
+if (config.stripTestSelectors) {
 
-  assert.equal(this.$('span').length, 1, 'the span is present');
-  assert.equal(this.$('span[data-test-id="my-id"]').length, 0, 'data-test-id is stripped');
-});
+  test('it strips data-test-* attributes', function (assert) {
+    this.render(hbs`<span data-test-id="my-id" ></span>`);
 
-test('it works with multiple data-test-* attributes', function(assert) {
-  this.render(hbs`<span data-test-first data-test-second"second-id" ></span>`);
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-test-id="my-id"]').length, 0, 'data-test-id is stripped');
+  });
 
-  assert.equal(this.$('span').length, 1, 'the span is present');
-  assert.equal(this.$('span[data-test-first]').length, 0, 'data-test-first is stripped');
-  assert.equal(this.$('span[data-test-second="second-id"]').length, 0, 'data-test-second is stripped');
-});
+  test('it works with multiple data-test-* attributes', function (assert) {
+    this.render(hbs`<span data-test-first data-test-second"second-id" ></span>`);
 
-test('it leaves other data attributes untouched, when a data-test-* attribute is present as well', function(assert) {
-  this.render(hbs`<span data-id="my-id" data-test-id="my-test-id" ></span>`);
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-test-first]').length, 0, 'data-test-first is stripped');
+    assert.equal(this.$('span[data-test-second="second-id"]').length, 0, 'data-test-second is stripped');
+  });
 
-  assert.equal(this.$('span').length, 1, 'the span is present');
-  assert.equal(this.$('span[data-id="my-id"]').length, 1, 'data-id is not stripped');
-  assert.equal(this.$('span[data-test-id="my-test-id"]').length, 0, 'data-test-id is stripped');
-});
+  test('it leaves other data attributes untouched, when a data-test-* attribute is present as well', function (assert) {
+    this.render(hbs`<span data-id="my-id" data-test-id="my-test-id" ></span>`);
 
-test('it leaves data-test attributes untouched', function(assert) {
-  this.render(hbs`<span data-test="my-id" ></span>`);
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-id="my-id"]').length, 1, 'data-id is not stripped');
+    assert.equal(this.$('span[data-test-id="my-test-id"]').length, 0, 'data-test-id is stripped');
+  });
 
-  assert.equal(this.$('span').length, 1, 'the span is present');
-  assert.equal(this.$('span[data-test="my-id"]').length, 1, 'data-test-id is not stripped');
-});
+  test('it leaves data-test attributes untouched', function (assert) {
+    this.render(hbs`<span data-test="my-id" ></span>`);
 
-test('it leaves other data attributes untouched', function(assert) {
-  this.render(hbs`<span data-id="my-id" ></span>`);
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-test="my-id"]').length, 1, 'data-test-id is not stripped');
+  });
 
-  assert.equal(this.$('span').length, 1, 'the span is present');
-  assert.equal(this.$('span[data-id="my-id"]').length, 1, 'data-id is not stripped');
-});
+  test('it leaves other data attributes untouched', function (assert) {
+    this.render(hbs`<span data-id="my-id" ></span>`);
+
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-id="my-id"]').length, 1, 'data-id is not stripped');
+  });
+
+} else {
+
+  test('it does not strip data-test-* attributes', function (assert) {
+    this.render(hbs`<span data-test-id="my-id" ></span>`);
+
+    assert.equal(this.$('span').length, 1, 'the span is present');
+    assert.equal(this.$('span[data-test-id="my-id"]').length, 1, 'data-test-id is not stripped');
+  });
+
+}


### PR DESCRIPTION
This introduces a `STRIP_TEST_SELECTORS` environment variables, which, if set, will enable test selector stripping for the `test` environment too. This allows us to test scenarios with and without test selector stripping without having to use `ember new` to initialize a second app (like ember-cli-addon-tests does).