### PR TITLE
Change "npm test" to only run tests for current ember-try scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - npm test -- --skip-cleanup
+  - npm run test:all -- --skip-cleanup
   - npm run lint
 
 notifications:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 module.exports = {
-  command: 'npm run test:both',
+  command: 'npm test',
   useVersionCompatibility: true,
   scenarios: [
     {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "ember build",
     "lint": "eslint config test-support tests *.js",
     "start": "ember server",
-    "test": "ember try:each",
-    "test:both": "npm run test:keep && npm run test:strip",
+    "test": "npm run test:keep && npm run test:strip",
+    "test:all": "ember try:each",
     "test:keep": "ember test",
     "test:strip": "STRIP_TEST_SELECTORS=true ember test"
   },


### PR DESCRIPTION
TravisCI will still test all scenarios, but locally a quick `npm test` will actually be quick now, while `npm run test:all` will kick off the test run that tests against all scenarios.