### PR TITLE
Simplify testSelector() import

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,10 @@ and integration tests:
 * `testSelector('post-title')`: Returns a selector `[data-test-post-title]`
 * `testSelector('resource-id', '2')`: Returns a selector `[data-test-resource-id="2"]`
 
-The test helpers can be imported from the `helpers/ember-test-selectors`
-module:
+The test helpers can be imported from the `ember-test-selectors` module:
 
 ```javascript
-import testSelector from '<app-name>/tests/helpers/ember-test-selectors';
+import testSelector from 'ember-test-selectors';
 ```
 
 ### Acceptance Test Usage

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function testSelector(key, value) {
+  return Ember.isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;
+}

--- a/test-support/helpers/ember-test-selectors.js
+++ b/test-support/helpers/ember-test-selectors.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
+import testSelector from 'ember-test-selectors';
 
-const {
-  isNone
-} = Ember;
+let message = 'Importing testSelector() from "<appname>/tests/helpers/ember-test-selectors" is deprecated. ' +
+  'Please import testSelector() from "ember-test-selectors" instead.';
 
-export default function testSelector(key, value) {
-  return isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;
-}
+Ember.deprecate(message, false, {
+  id: 'ember-test-selectors.test-selector-import',
+  until: '0.1.0',
+  url: 'https://github.com/simplabs/ember-test-selectors#test-helpers',
+});
+
+export default testSelector;

--- a/tests/unit/test-selector-test.js
+++ b/tests/unit/test-selector-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+
+import testSelector from 'ember-test-selectors';
+
+module('Unit | testSelector() from "ember-test-selectors"');
+
+test('expands a selector name and attribute value corretly', function(assert) {
+  assert.equal(testSelector('selector', 'welcome-text'), '[data-test-selector="welcome-text"]');
+  assert.equal(testSelector('selector', 0), '[data-test-selector="0"]');
+});
+
+test('expands a selector name without attribute value corretly', function(assert) {
+  assert.equal(testSelector('selector'), '[data-test-selector]');
+});


### PR DESCRIPTION
```js
import testSelector from 'ember-test-selectors';
```

instead of

```js
import testSelector from '<app-name>/tests/helpers/ember-test-selectors';
```

The old import still works, but displays a deprecation warning. Due to the fact that our `addon` and `app` folders are only packaged in testing mode we don't have to worry about including testing code in the production build.