### PR TITLE
Fix default setting for "strip" option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     } else if ('strip' in addonOptions) {
       this._stripTestSelectors = addonOptions.strip;
     } else {
-      this._stripTestSelectors = app.tests;
+      this._stripTestSelectors = !app.tests;
     }
   },
 


### PR DESCRIPTION
The selectors should obviously only be stripped when there are no tests...! 🙈