### PR TITLE
Add Babel 5 plugin stripping "data-test-*" properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - npm run test:all -- --skip-cleanup
+  - npm run test:node
   - npm run lint
 
 notifications:

--- a/index.js
+++ b/index.js
@@ -39,6 +39,22 @@ module.exports = {
     }
   },
 
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    // add the StripDataTestPropertiesPlugin to the list of plugins used by
+    // the `ember-cli-babel` addon
+    if (this._stripTestSelectors && !this._registeredWithBabel) {
+      app.options = app.options || {};
+      app.options.babel = app.options.babel || {};
+      app.options.babel.plugins = app.options.babel.plugins || [];
+
+      app.options.babel.plugins.push(require('./strip-data-test-properties-plugin'));
+
+      this._registeredWithBabel = true;
+    }
+  },
+
   treeForAddon: function() {
     // remove our "addon" folder from the build if we're stripping test selectors
     if (!this._stripTestSelectors) {

--- a/node-tests/.eslintignore
+++ b/node-tests/.eslintignore
@@ -1,0 +1,1 @@
+fixtures

--- a/node-tests/.eslintrc.js
+++ b/node-tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    mocha: true
+  },
+};

--- a/node-tests/fixtures/default/expected.js
+++ b/node-tests/fixtures/default/expected.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _ember = require('ember');
+
+var _ember2 = _interopRequireDefault(_ember);
+
+exports['default'] = _ember2['default'].Component.extend({
+  foo: 'foo',
+  'data-test': 'test'
+});
+module.exports = exports['default'];

--- a/node-tests/fixtures/default/fixture.js
+++ b/node-tests/fixtures/default/fixture.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  foo: 'foo',
+  'data-test': 'test',
+  'data-test-foo': 'foo',
+  'data-test-foobar': Ember.computed('data-test-foo', function() {
+    return `${this.get('data-test-foo')}bar`
+  }),
+});

--- a/node-tests/strip-data-test-properties-plugin-test.js
+++ b/node-tests/strip-data-test-properties-plugin-test.js
@@ -1,0 +1,24 @@
+var fs = require('fs');
+var assert = require('assert');
+
+var babel = require('babel-core');
+var StripDataTestPropertiesPlugin = require('../strip-data-test-properties-plugin');
+
+function testFixture(name) {
+  it('fixture: ' + name, function() {
+    var fixturePath = __dirname + '/fixtures/' + name + '/fixture.js';
+    var expectedPath = __dirname + '/fixtures/' + name + '/expected.js';
+
+    var expected = fs.readFileSync(expectedPath).toString();
+    var result = babel.transformFileSync(fixturePath, {
+      plugins: [StripDataTestPropertiesPlugin],
+    });
+
+    assert.strictEqual(result.code.trim(), expected.trim());
+  });
+}
+
+describe('StripDataTestProperties plugin', function() {
+  testFixture('default');
+});
+

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {
+    "babel-core": "^5.8.38",
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-stew": "^1.4.0",
     "ember-ajax": "^2.4.1",
@@ -45,7 +46,8 @@
     "ember-load-initializers": "^0.6.3",
     "ember-resolver": "^2.0.3",
     "eslint": "^3.12.2",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.0.10",
+    "mocha": "^3.2.0"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "npm run test:keep && npm run test:strip",
     "test:all": "ember try:each",
     "test:keep": "ember test",
+    "test:node": "mocha node-tests",
     "test:strip": "STRIP_TEST_SELECTORS=true ember test"
   },
   "dependencies": {

--- a/strip-data-test-properties-plugin.js
+++ b/strip-data-test-properties-plugin.js
@@ -1,0 +1,23 @@
+var TEST_SELECTOR_PREFIX = /data-test-.*/;
+
+function StripDataTestPropertiesPlugin(babel) {
+  return new babel.Plugin('ember-test-selectors', {
+    visitor: {
+      Property: function(node) {
+        if (TEST_SELECTOR_PREFIX.test(node.key.value)) {
+          this.dangerouslyRemove();
+        }
+      },
+    },
+  });
+}
+
+StripDataTestPropertiesPlugin.baseDir = function() {
+  return __dirname;
+};
+
+StripDataTestPropertiesPlugin.cacheKey = function() {
+  return 'ember-test-selectors.strip-data-test-properties';
+};
+
+module.exports = StripDataTestPropertiesPlugin;


### PR DESCRIPTION
This plugin will be added automatically to the Babel configuration of the host app and removes all `data-test-*` properties that it finds in JS code.