### PR TITLE
add blueprint + test helper for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Installation
 ember install ember-test-selectors
 ```
 
+When you install the addon, it should automatically generate a helper located at
+`tests/helpers/test-selectors.js` as well as add an import to load that helper
+in `tests/test-helper.js`. This sets up the component `data-test-*` auto-binding
+for integration tests.
+
+You can do this manually as well:
+
+```
+$ ember generate ember-test-selectors
+```
 
 Usage
 ------------------------------------------------------------------------------

--- a/blueprints/.eslintrc.js
+++ b/blueprints/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  },
+  env: {
+    node: null,
+    browser: true,
+    embertest: true,
+  },
+};

--- a/blueprints/files/tests/helpers/test-selectors.js
+++ b/blueprints/files/tests/helpers/test-selectors.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import bindDataTestAttributes from 'ember-test-selectors/utils/bind-data-test-attributes';
+
+const { Component } = Ember;
+
+Component.reopen({
+  init() {
+    this._super(...arguments);
+    bindDataTestAttributes(this);
+  }
+});

--- a/blueprints/index.js
+++ b/blueprints/index.js
@@ -1,0 +1,17 @@
+var EOL = require('os').EOL;
+
+module.exports = {
+  description: 'Generates ember-test-selectors test helper',
+
+  afterInstall: function() {
+    var TEST_HELPER_PATH = 'tests/test-helper.js';
+    var IMPORT_STATEMENT = EOL + "import './helpers/test-selectors';";
+    var INSERT_AFTER = "import resolver from './helpers/resolver';";
+
+    return this.insertIntoFile(TEST_HELPER_PATH, IMPORT_STATEMENT, {
+      after: INSERT_AFTER
+    });
+  },
+
+  normalizeEntityName: function() {}
+};


### PR DESCRIPTION
Borrowing from an approach used by [ember-cli-flash](https://github.com/poteto/ember-cli-flash), we add a helper to duplicate the behavior of the initializer when we're running an integration test (where initializers are not loaded). Also, add a blueprint that auto-installs this helper and loads it in `tests/test-helepr.js`.

I haven't actually run the blueprint itself, but I did manually make the changes it would make on my own app and that fixed the issue I was having.

Hopefully this does the trick!

Fixes #49.