### PR TITLE
Add support for component data-test-* attributes without values

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,14 @@ module.exports = {
           plugin: StripTestSelectorsTransform,
           baseDir: function() { return __dirname; }
         });
+      } else {
+        var TransformTestSelectorParamsToHashPairs = require('./transform-test-selector-params-to-hash-pairs');
+
+        registry.add('htmlbars-ast-plugin', {
+          name: 'transform-test-selector-params-to-hash-pairs',
+          plugin: TransformTestSelectorParamsToHashPairs,
+          baseDir: function() { return __dirname; }
+        });
       }
     }
   },

--- a/tests/acceptance/bind-data-test-attributes-in-components-test.js
+++ b/tests/acceptance/bind-data-test-attributes-in-components-test.js
@@ -47,5 +47,8 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test6').find('div[data-non-test]').length, 0, 'data-non-test does not exists');
   });
 
-}
+  test('it binds data-test-* attributes without values on components', function (assert) {
+    assert.equal(find('.test7').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
 
+}

--- a/tests/dummy/app/templates/bind-test.hbs
+++ b/tests/dummy/app/templates/bind-test.hbs
@@ -9,3 +9,5 @@
 <div class="test5">{{data-test-component data-test="foo"}}</div>
 
 <div class="test6">{{data-test-component data-non-test="foo"}}</div>
+
+<div class="test7">{{data-test-component data-test-without-value}}</div>

--- a/transform-test-selector-params-to-hash-pairs.js
+++ b/transform-test-selector-params-to-hash-pairs.js
@@ -1,0 +1,42 @@
+/* eslint-env node */
+var TEST_SELECTOR_PREFIX = /data-test-.*/;
+
+function TransformTestSelectorParamsToHashPairs() {
+  this.syntax = null;
+}
+
+function isTestSelectorParam(param) {
+  return param.type === 'PathExpression'
+    && TEST_SELECTOR_PREFIX.test(param.original);
+}
+
+TransformTestSelectorParamsToHashPairs.prototype.transform = function(ast) {
+  var b = this.syntax.builders;
+  var traverse = this.syntax.traverse;
+
+  traverse(ast, {
+    MustacheStatement: function(node) {
+      var testSelectorParams = [];
+      var otherParams = [];
+
+      node.params.forEach(function(param) {
+        if (isTestSelectorParam(param)) {
+          testSelectorParams.push(param);
+        } else {
+          otherParams.push(param);
+        };
+      });
+
+      node.params = otherParams;
+
+      testSelectorParams.forEach(function(param) {
+        var pair = b.pair(param.original, b.boolean(true));
+        node.hash.pairs.push(pair);
+      });
+    }
+  });
+
+  return ast;
+};
+
+module.exports = TransformTestSelectorParamsToHashPairs;


### PR DESCRIPTION
### Transforms

```handlebars
{{my-component data-test-foo}}
```

to:

```handlebars
{{my-component data-test-foo=true}}
```

### Description

This adds support for `{{my-component data-test-foo}}`.

Basically, this adds a handlebars transform that converts the previous example to `{{my-component data-test-foo=true}}`, which already works.

I understand if you'd rather not accept this feature but I thought it might be nice since this style selector is supported for regular elements 😄 

### Use case:

The app I'm currently working on uses a lot of `<div data-test-foo>` style test selectors. I'd like to extract some of these elements into components but the current situation with the component support would require either coming up with values for each of the `data-test-*` attributes or using `data-test-foo=true` throughout the app.