### PR TITLE
Add support for component data-test-* attributes without values

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,14 @@ module.exports = {
           plugin: StripTestSelectorsTransform,
           baseDir: function() { return __dirname; }
         });
+      } else {
+        var TransformTestSelectorParamsToHashPairs = require('./transform-test-selector-params-to-hash-pairs');
+
+        registry.add('htmlbars-ast-plugin', {
+          name: 'transform-test-selector-params-to-hash-pairs',
+          plugin: TransformTestSelectorParamsToHashPairs,
+          baseDir: function() { return __dirname; }
+        });
       }
     }
   },

--- a/tests/acceptance/bind-data-test-attributes-in-components-test.js
+++ b/tests/acceptance/bind-data-test-attributes-in-components-test.js
@@ -47,5 +47,8 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test6').find('div[data-non-test]').length, 0, 'data-non-test does not exists');
   });
 
-}
+  test('it binds data-test-* attributes without values on components', function (assert) {
+    assert.equal(find('.test7').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
 
+}

--- a/tests/acceptance/bind-data-test-attributes-in-components-test.js
+++ b/tests/acceptance/bind-data-test-attributes-in-components-test.js
@@ -39,7 +39,7 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test4').find('div[data-non-test]').length, 0, 'data-non-test does not exists');
   });
 
-  test('it leaves data-test attributes untouched on components', function (assert) {
+  test('it leaves data-test attribute untouched on components', function (assert) {
     assert.equal(find('.test5').find('div[data-test]').length, 0, 'data-test does not exists');
   });
 
@@ -47,8 +47,20 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test6').find('div[data-non-test]').length, 0, 'data-non-test does not exists');
   });
 
+  test('it binds data-test-* attributes with boolean values on components', function (assert) {
+    assert.equal(find('.test7').find('div[data-test-with-boolean-value]').length, 1, 'data-test-with-boolean-value exists');
+  });
+
   test('it binds data-test-* attributes without values on components', function (assert) {
-    assert.equal(find('.test7').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+    assert.equal(find('.test8').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
+
+  test('it binds data-test-* attributes without values on block components', function (assert) {
+    assert.equal(find('.test9').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
+
+  test('it leaves data-test attribute without value untouched on components', function (assert) {
+    assert.equal(find('.test10').find('div[data-test]').length, 0, 'data-test does not exists');
   });
 
 }

--- a/tests/dummy/app/templates/bind-test.hbs
+++ b/tests/dummy/app/templates/bind-test.hbs
@@ -10,4 +10,10 @@
 
 <div class="test6">{{data-test-component data-non-test="foo"}}</div>
 
-<div class="test7">{{data-test-component data-test-without-value}}</div>
+<div class="test7">{{data-test-component data-test-with-boolean-value=true}}</div>
+
+<div class="test8">{{data-test-component data-test-without-value}}</div>
+
+<div class="test9">{{#data-test-component data-test-without-value}}foo{{/data-test-component}}</div>
+
+<div class="test10">{{data-test-component data-test}}</div>

--- a/tests/dummy/app/templates/bind-test.hbs
+++ b/tests/dummy/app/templates/bind-test.hbs
@@ -9,3 +9,5 @@
 <div class="test5">{{data-test-component data-test="foo"}}</div>
 
 <div class="test6">{{data-test-component data-non-test="foo"}}</div>
+
+<div class="test7">{{data-test-component data-test-without-value}}</div>

--- a/transform-test-selector-params-to-hash-pairs.js
+++ b/transform-test-selector-params-to-hash-pairs.js
@@ -1,0 +1,42 @@
+/* eslint-env node */
+var TEST_SELECTOR_PREFIX = /data-test-.*/;
+
+function TransformTestSelectorParamsToHashPairs() {
+  this.syntax = null;
+}
+
+function isTestSelectorParam(param) {
+  return param.type === 'PathExpression'
+    && TEST_SELECTOR_PREFIX.test(param.original);
+}
+
+TransformTestSelectorParamsToHashPairs.prototype.transform = function(ast) {
+  var b = this.syntax.builders;
+  var traverse = this.syntax.traverse;
+
+  traverse(ast, {
+    MustacheStatement: function(node) {
+      var testSelectorParams = [];
+      var otherParams = [];
+
+      node.params.forEach(function(param) {
+        if (isTestSelectorParam(param)) {
+          testSelectorParams.push(param);
+        } else {
+          otherParams.push(param);
+        };
+      });
+
+      node.params = otherParams;
+
+      testSelectorParams.forEach(function(param) {
+        var pair = b.pair(param.original, b.boolean(true));
+        node.hash.pairs.push(pair);
+      });
+    }
+  });
+
+  return ast;
+};
+
+module.exports = TransformTestSelectorParamsToHashPairs;

--- a/transform-test-selector-params-to-hash-pairs.js
+++ b/transform-test-selector-params-to-hash-pairs.js
@@ -12,10 +12,10 @@ function isTestSelectorParam(param) {
 
 TransformTestSelectorParamsToHashPairs.prototype.transform = function(ast) {
   var b = this.syntax.builders;
-  var traverse = this.syntax.traverse;
+  var walker = new this.syntax.Walker();
 
-  traverse(ast, {
-    MustacheStatement: function(node) {
+  walker.visit(ast, function(node) {
+    if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
       var testSelectorParams = [];
       var otherParams = [];
 
@@ -24,7 +24,7 @@ TransformTestSelectorParamsToHashPairs.prototype.transform = function(ast) {
           testSelectorParams.push(param);
         } else {
           otherParams.push(param);
-        };
+        }
       });
 
       node.params = otherParams;


### PR DESCRIPTION
This PR is essentially #55 with a small change that restores Ember 1.13 compatibility.