### PR TITLE
attributeBindings is now frozen in debug builds on v2.11, slice it before pushing

### DIFF
--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -37,6 +37,8 @@ export default function bindDataTestAttributes(component) {
   let attributeBindings = component.getWithDefault('attributeBindings', []);
   if (!Ember.isArray(attributeBindings)) {
     attributeBindings = [attributeBindings];
+  } else {
+    attributeBindings = attributeBindings.slice();
   }
 
   dataTestProperties.forEach(it => attributeBindings.push(it));


### PR DESCRIPTION
As noted in the Ember v2.11 release notes, concatenated properties such as attributeBindings are frozen in debug builds. This means we cannot push directly onto the attributeBindings array without first copying it via slice.

Without this change, users may see errors like this when the `attributeBindings.push()` call is made:

```
Uncaught TypeError: Can't add property 2, object is not extensible
```

References:

* http://emberjs.com/blog/2017/01/23/ember-2-11-released.html#toc_other-notable-changes
* https://github.com/emberjs/ember.js/pull/14389
* https://github.com/emberjs/ember.js/issues/14601