### PR TITLE
fix: strip data-test-* attributes without explicit value from production build

### DIFF
--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -4,8 +4,8 @@
 
 let TEST_SELECTOR_PREFIX = /data-test-.*/;
 
-function isNotTestSelector(attribute) {
-  return !TEST_SELECTOR_PREFIX.test(attribute);
+function isTestSelector(attribute) {
+  return TEST_SELECTOR_PREFIX.test(attribute);
 }
 
 function StripTestSelectorsTransform() {
@@ -18,15 +18,15 @@ StripTestSelectorsTransform.prototype.transform = function(ast) {
   walker.visit(ast, function(node) {
     if (node.type === 'ElementNode') {
       node.attributes = node.attributes.filter(function(attribute) {
-        return isNotTestSelector(attribute.name);
+        return !isTestSelector(attribute.name);
       });
     } else if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
       node.params = node.params.filter(function(param) {
-        return isNotTestSelector(param.original);
+        return !isTestSelector(param.original);
       });
 
       node.hash.pairs = node.hash.pairs.filter(function(pair) {
-        return isNotTestSelector(pair.key);
+        return !isTestSelector(pair.key);
       });
     }
   });

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -4,6 +4,10 @@
 
 let TEST_SELECTOR_PREFIX = /data-test-.*/;
 
+function isNotTestSelector(attribute) {
+  return !TEST_SELECTOR_PREFIX.test(attribute);
+}
+
 function StripTestSelectorsTransform() {
   this.syntax = null;
 }
@@ -14,11 +18,15 @@ StripTestSelectorsTransform.prototype.transform = function(ast) {
   walker.visit(ast, function(node) {
     if (node.type === 'ElementNode') {
       node.attributes = node.attributes.filter(function(attribute) {
-        return !TEST_SELECTOR_PREFIX.test(attribute.name);
+        return isNotTestSelector(attribute.name);
       });
     } else if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+      node.params = node.params.filter(function(param) {
+        return isNotTestSelector(param.original);
+      });
+
       node.hash.pairs = node.hash.pairs.filter(function(pair) {
-        return !TEST_SELECTOR_PREFIX.test(pair.key);
+        return isNotTestSelector(pair.key);
       });
     }
   });

--- a/tests/dummy/app/components/print-test-attributes.js
+++ b/tests/dummy/app/components/print-test-attributes.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+const component = Component.extend();
+
+component.reopenClass({
+  positionalParams: 'params'
+});
+
+export default component;

--- a/tests/dummy/app/templates/components/print-test-attributes.hbs
+++ b/tests/dummy/app/templates/components/print-test-attributes.hbs
@@ -2,3 +2,4 @@
 <div class="data-test-second">{{data-test-second}}</div>
 <div class="data-non-test">{{data-non-test}}</div>
 <div class="data-test">{{data-test}}</div>
+<div class="data-test-positional-params">{{params.length}}</div>

--- a/tests/integration/strip-data-test-attributes-from-components-test.js
+++ b/tests/integration/strip-data-test-attributes-from-components-test.js
@@ -9,6 +9,12 @@ moduleForComponent('print-test-attributes', 'StripTestSelectorsTransform plugin'
 
 if (config.stripTestSelectors) {
 
+  test('it strips data-test-* attributes from components with positional params', function(assert) {
+    this.render(hbs`{{print-test-attributes "param1" data-test-first}}`);
+
+    assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be only one param');
+  });
+
   test('it strips data-test-* attributes from components', function(assert) {
     this.render(hbs`{{print-test-attributes data-test-first="foobar"}}`);
 

--- a/tests/integration/strip-data-test-attributes-from-components-test.js
+++ b/tests/integration/strip-data-test-attributes-from-components-test.js
@@ -9,8 +9,26 @@ moduleForComponent('print-test-attributes', 'StripTestSelectorsTransform plugin'
 
 if (config.stripTestSelectors) {
 
-  test('it strips data-test-* attributes from components with positional params', function(assert) {
-    this.render(hbs`{{print-test-attributes "param1" data-test-first}}`);
+  test('it strips data-test-* attributes from components with single positional params', function(assert) {
+    this.render(hbs`{{print-test-attributes data-test-should-not-be}}`);
+
+    assert.equal(this.$('.data-test-positional-params').text(), 0, 'there should be no params');
+  });
+
+  test('it strips data-test-* attributes from components with positional params data-test-* as first param', function(assert) {
+    this.render(hbs`{{print-test-attributes data-test-should-not-be "param1"}}`);
+
+    assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be no params');
+  });
+
+  test('it strips data-test-* attributes from components with multiple positional params', function(assert) {
+    this.render(hbs`{{print-test-attributes "param1" data-test-should-not-be}}`);
+
+    assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be only one param');
+  });
+
+  test('it strips data-test-* attributes from components with block and multiple positional params', function(assert) {
+    this.render(hbs`{{#print-test-attributes "param1" data-test-should-not-be}}{{/print-test-attributes}}`);
 
     assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be only one param');
   });

--- a/tests/integration/strip-data-test-attributes-from-components-test.js
+++ b/tests/integration/strip-data-test-attributes-from-components-test.js
@@ -18,7 +18,7 @@ if (config.stripTestSelectors) {
   test('it strips data-test-* attributes from components with positional params data-test-* as first param', function(assert) {
     this.render(hbs`{{print-test-attributes data-test-should-not-be "param1"}}`);
 
-    assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be no params');
+    assert.equal(this.$('.data-test-positional-params').text(), 1, 'there should be only one param');
   });
 
   test('it strips data-test-* attributes from components with multiple positional params', function(assert) {


### PR DESCRIPTION
Fixes use case like:

`{{my-component "param1" data-test-something}}`

Real world example:

`{{#link-to 'route' data-test-link}}Link{{/link-to}}`

This would fail on production build by being completely broken link, because link-to actually would receive` 'route' undefined` as input. As second argument is meant to be "model" on link-to, then this causes major problems.

Sorry for the package.json showing up in diff, rebased went a bit into woods.