### PR TITLE
Add "ts" template string handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Enabling better element selectors in [Ember.js](http://emberjs.com) tests
 Features
 ------------------------------------------------------------------------------
 
-- Provides a `testSelector()` function to help you select the right elements
+- Provides a `ts` template string handler to help you select the right 
+  elements
 
 - Removes attributes starting with `data-test-` from HTML tags and
   component/helper invocations in your templates for production builds
@@ -52,21 +53,22 @@ automatically removed from `production` builds:
 </article>
 ```
 
-Once you've done that you can use the `testSelector()` function to create
+Once you've done that you can use the `ts` template string handler to create
 a CSS/jQuery selector that looks up the right elements:
 
 ```js
-import testSelector from 'ember-test-selectors';
+import { ts } from 'ember-test-selectors';
 
 // in Acceptance Tests:
 
-find(testSelector('post-title')) // => find('[data-test-post-title]')
-find(testSelector('resource-id', '2')) // => find('[data-test-resource-id="2"]')
+find(ts`%post-title`); // => find('[data-test-post-title]');
+find(ts`%resource-id=2`); // => find('[data-test-resource-id="2"]');
+find(ts`.blog %post-title input`); // => find('.blog [data-test-post-title] input');
 
 // in Component Integration Tests:
 
-this.$(testSelector('post-title')).click() // => this.$('[data-test-post-title]').click()
-this.$(testSelector('resource-id', '2')).click() // => this.$('[data-test-resource-id="2"]').click()
+this.$(ts`%post-title`).click(); // => this.$('[data-test-post-title]').click();
+this.$(ts`%resource-id=2`).click(); // => this.$('[data-test-resource-id="2"]').click();
 ```
 
 ### Usage in Components

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,23 @@
 import Ember from 'ember';
 
-const { isNone } = Ember;
+const { isNone, warn } = Ember;
 
 export default function testSelector(key, value) {
   return isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;
+}
+
+export function ts(literals, ...substitutions) {
+  let interpolated = literals[0] + substitutions.map((_, i) => substitutions[i] + literals[i + 1]).join('');
+  if (interpolated.indexOf('%') === -1) {
+    warn(`[ember-test-selectors] "${interpolated}" contains no test selectors. Please use the % prefix for test selectors (e.g. ts\`%foo\`).`, false, {
+      id: 'ember-test-selectors.missing-test-selector-prefix',
+    });
+    return interpolated;
+  }
+
+  return interpolated
+    .replace(/%([\w-_]+)="([^"]*)"/g, (match, name, value) => `[data-test-${name}="${value}"]`)
+    .replace(/%([\w-_]+)='([^']*)'/g, (match, name, value) => `[data-test-${name}="${value}"]`)
+    .replace(/%([\w-_]+)=([^\s]+)/g, (match, name, value) => `[data-test-${name}="${value}"]`)
+    .replace(/%([\w-_]+)/g, (match, name) => `[data-test-${name}]`);
 }

--- a/tests/unit/ts-test.js
+++ b/tests/unit/ts-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+
+import { ts } from 'ember-test-selectors';
+
+module('Unit | ts');
+
+test('converts %-prefixed tokens to data-test selectors', function(assert) {
+  function check(input, output) {
+    assert.equal(input, output, output);
+  }
+
+  check(ts`h1`, 'h1');
+  check(ts`.foo`, '.foo');
+  check(ts`%foo`, '[data-test-foo]');
+  check(ts`%foo=1`, '[data-test-foo="1"]');
+  check(ts`%foo=bar`, '[data-test-foo="bar"]');
+  check(ts`%foo="bar"`, '[data-test-foo="bar"]');
+  check(ts`%foo="bar baz"`, '[data-test-foo="bar baz"]');
+  check(ts`%foo="bar" baz`, '[data-test-foo="bar"] baz');
+  check(ts`%foo='bar' baz`, '[data-test-foo="bar"] baz');
+  check(ts`%foo=bar baz`, '[data-test-foo="bar"] baz');
+  check(ts`.foo %bar #baz`, '.foo [data-test-bar] #baz');
+
+  check(ts`%primitive-list-header .foo %pointer=3`,
+    '[data-test-primitive-list-header] .foo [data-test-pointer="3"]');
+
+  check(ts`%foo=${'bar'}`, '[data-test-foo="bar"]');
+  check(ts`%${'foo'}=${'bar'}`, '[data-test-foo="bar"]');
+  check(ts`.foo %bar=${5} #bar %foo .${'blubb'}`, '.foo [data-test-bar="5"] #bar [data-test-foo] .blubb');
+  check(ts`.foo ${'%bar'}`, '.foo [data-test-bar]');
+
+  // The following examples are "broken" but fixing them properly would require
+  // a custom CSS selector parser which is out-of-scope for this addon. If you
+  // have such a use case please assemble the test selector manually.
+
+  check(ts`%foo='bar" baz`, '[data-test-foo="\'bar""] baz');
+  check(ts`[value="foo %bar baz"]`, '[value="foo [data-test-bar] baz"]');
+});


### PR DESCRIPTION
... as a replacement for the verbose `testSelector()` function.

This PR does not yet deprecate the `testSelector()` function, but replaces it in the README.

## Examples

```js
assert.equal(ts`h1`, 'h1');
assert.equal(ts`.foo`, '.foo');
assert.equal(ts`%foo`, '[data-test-foo]');
assert.equal(ts`%foo=1`, '[data-test-foo="1"]');
assert.equal(ts`%foo=bar`, '[data-test-foo="bar"]');
assert.equal(ts`%foo="bar"`, '[data-test-foo="bar"]');
assert.equal(ts`%foo="bar baz"`, '[data-test-foo="bar baz"]');
assert.equal(ts`%foo="bar" baz`, '[data-test-foo="bar"] baz');
assert.equal(ts`%foo='bar' baz`, '[data-test-foo="bar"] baz');
assert.equal(ts`%foo=bar baz`, '[data-test-foo="bar"] baz');
assert.equal(ts`.foo %bar #baz`, '.foo [data-test-bar] #baz');
assert.equal(ts`%primitive-list-header .foo %pointer=3`, '[data-test-primitive-list-header] .foo [data-test-pointer="3"]');
assert.equal(ts`%foo=${'bar'}`, '[data-test-foo="bar"]');
assert.equal(ts`.foo %bar=${5} #bar %foo .${'blubb'}`, '.foo [data-test-bar="5"] #bar [data-test-foo] .blubb');
assert.equal(ts`.foo ${'%bar'}`, '.foo [data-test-bar]');
```

Resolves #121

/cc @kellyselden