### PR TITLE
Fix Babel version detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = {
     // add the StripDataTestPropertiesPlugin to the list of plugins used by
     // the `ember-cli-babel` addon
     if (this._stripTestSelectors && !this._registeredWithBabel) {
-      let checker = new VersionChecker(this).for('ember-cli-babel', 'npm');
+      let checker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
 
       app.options = app.options || {};
 


### PR DESCRIPTION
`this` obviously referred to the addon itself and this only worked before because `ember-test-selectors` itself does not depend on `ember-cli-babel`. Using `this.parent` instead will check the `ember-cli-babel` version of the parent (either addon or app) which is the correct behavior, even for using it as a nested addon.

Resolves #130 

/cc @rwjblue