### PR TITLE
Deprecate testSelector() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Enabling better element selectors in [Ember.js](http://emberjs.com) tests
 Features
 ------------------------------------------------------------------------------
 
-- Provides a `testSelector()` function to help you select the right elements
-
 - Removes attributes starting with `data-test-` from HTML tags and
   component/helper invocations in your templates for production builds
 
@@ -52,21 +50,18 @@ automatically removed from `production` builds:
 </article>
 ```
 
-Once you've done that you can use the `testSelector()` function to create
-a CSS/jQuery selector that looks up the right elements:
+Once you've done that you can use attribute selectors to look up the elements:
 
 ```js
-import testSelector from 'ember-test-selectors';
-
 // in Acceptance Tests:
 
-find(testSelector('post-title')) // => find('[data-test-post-title]')
-find(testSelector('resource-id', '2')) // => find('[data-test-resource-id="2"]')
+find('[data-test-post-title]')
+find('[data-test-resource-id="2"]')
 
 // in Component Integration Tests:
 
-this.$(testSelector('post-title')).click() // => this.$('[data-test-post-title]').click()
-this.$(testSelector('resource-id', '2')).click() // => this.$('[data-test-resource-id="2"]').click()
+this.$('[data-test-post-title]').click()
+this.$('[data-test-resource-id="2"]').click()
 ```
 
 ### Usage in Components

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,16 @@
 import Ember from 'ember';
 
-const { isNone } = Ember;
+const { isNone, deprecate } = Ember;
+
+const message = `Using the "testSelector" helper function is deprecated as it obfuscates the selectors, making the tests harder to understand.
+Please use the actual attribute selectors instead, e.g. "[data-test-my-element]" instead of "testSelector('my-element')".`;
 
 export default function testSelector(key, value) {
+  deprecate(message, false, {
+    id: 'ember-test-selectors.test-selector-helper',
+    until: '0.4.0',
+    url: 'https://github.com/simplabs/ember-test-selectors#usage',
+  });
+
   return isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;
 }


### PR DESCRIPTION
This deprecates the `testSelector` helper and propagates using the respective attribute selectors directly instead. Besides obfuscating what's going on, the `testSelector` helper doesn't really do much.