### PR TITLE
Added a link to the deprecations warning to point to a codemod to help address it

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ was triggered by `ember test`. That means that if you use
 `ember test --environment=production` the test selectors will still work, but
 for `ember build -prod` they will be stripped out.
 
+Deprecations
+------------------------------------------------------------------------------
+
+The `testSelector` helper was deprecated in [v0.3.7](https://github.com/simplabs/ember-test-selectors/releases/tag/v0.3.7).
+There's a codemod available at https://github.com/lorcan/test-selectors-codemod
+that can help make the necessary transformations to address the deprecation.
 
 License
 ------------------------------------------------------------------------------

--- a/addon/index.js
+++ b/addon/index.js
@@ -9,7 +9,7 @@ export default function testSelector(key, value) {
   deprecate(message, false, {
     id: 'ember-test-selectors.test-selector-helper',
     until: '0.4.0',
-    url: 'https://github.com/simplabs/ember-test-selectors#usage',
+    url: 'https://github.com/simplabs/ember-test-selectors#deprecations',
   });
 
   return isNone(value) ? `[data-test-${key}]` : `[data-test-${key}="${value}"]`;


### PR DESCRIPTION
Hi folks, I wrote up a codemod to help address the testSelector deprecation introduced in https://github.com/simplabs/ember-test-selectors/pull/134.

The codemod is here: https://github.com/lorcan/test-selectors-codemod

I thought it might be helpful to add a link to the codemod to the deprecation warning in the hopes that it makes it a little easier to fix :-)