### PR TITLE
feat(transform): Adds an option to disable the param transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = {
     } else {
       this._stripTestSelectors = !app.tests;
     }
+
+    this._disableParamTransform = addonOptions.disableParamTransform;
   },
 
   _setupPreprocessorRegistry(registry) {
@@ -36,7 +38,7 @@ module.exports = {
         baseDir() { return __dirname; },
         cacheKey() { return 'strip-test-selectors'; },
       });
-    } else {
+    } else if (!this._disableParamTransform) {
       let TransformTestSelectorParamsToHashPairs = require('./transform-test-selector-params-to-hash-pairs');
 
       registry.add('htmlbars-ast-plugin', {


### PR DESCRIPTION
Currently this addon runs a handlebars transform which converts positional parameters in components that begin with `data-test` into named parameters:

```hbs
<!-- Before -->

{{foo-component data-test-foo }}

<!-- After -->

{{foo-component data-test-foo=true}}

```

This breaks on older versions of Ember/HTMLbars, and in general is a somewhat brittle pattern because parameters _must_ always come first in a component. This PR adds the `disableParamTransform` option to the addon's ember-cli options which allows users to opt-out if they don't want to allow this behavior.