### PR TITLE
add acceptance test for params-to-hash-pairs transform

### DIFF
--- a/tests/acceptance/bind-data-test-attributes-in-components-test.js
+++ b/tests/acceptance/bind-data-test-attributes-in-components-test.js
@@ -63,4 +63,7 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test10').find('div[data-test]').length, 0, 'data-test does not exists');
   });
 
+  test('it transforms data-test params to hash pairs on components', function(assert) {
+    assert.equal(find('.test11').find('div[data-test-something]').length, 1, 'data-test-something exists');
+  });
 }

--- a/tests/dummy/app/templates/bind-test.hbs
+++ b/tests/dummy/app/templates/bind-test.hbs
@@ -17,3 +17,5 @@
 <div class="test9">{{#data-test-component data-test-without-value}}foo{{/data-test-component}}</div>
 
 <div class="test10">{{data-test-component data-test}}</div>
+
+<div class="test11">{{data-test-component data-test-something some-prop="prop"}}</div>


### PR DESCRIPTION
…we didn't actually have an acceptance test for this previously which is why the changes in #150 don't break the build while they actually should.