### PR TITLE
Fix positional to hash params transform for Ember 1.11/1.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,13 +55,9 @@ module.exports = {
     let host = this._findHost();
     this._assignOptions(host);
 
-    let emberChecker = new VersionChecker(app).forEmber();
-
-    if (emberChecker.isAbove('1.13.0')) {
-      // we can't use the setupPreprocessorRegistry() hook as it is called to
-      // early and we do not have reliable access to `app.tests` there yet
-      this._setupPreprocessorRegistry(app.registry);
-    }
+    // we can't use the setupPreprocessorRegistry() hook as it is called to
+    // early and we do not have reliable access to `app.tests` there yet
+    this._setupPreprocessorRegistry(app.registry);
 
     // add the StripDataTestPropertiesPlugin to the list of plugins used by
     // the `ember-cli-babel` addon

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
-    "ember-compatibility-helpers": "^0.1.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.3.0",

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -21,6 +21,10 @@ StripTestSelectorsTransform.prototype.transform = function(ast) {
         return !isTestSelector(attribute.name);
       });
     } else if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+      if ('sexpr' in node) {
+        node = node.sexpr;
+      }
+
       node.params = node.params.filter(function(param) {
         return !isTestSelector(param.original);
       });

--- a/tests/acceptance/bind-data-test-attributes-in-components-test.js
+++ b/tests/acceptance/bind-data-test-attributes-in-components-test.js
@@ -1,9 +1,8 @@
-import { test } from 'qunit';
+import { test, skip } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 import config from 'dummy/config/environment';
-
-import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
+import { hasPositionalParams } from 'dummy/version-checks';
 
 if (!config.stripTestSelectors) {
 
@@ -49,25 +48,23 @@ if (!config.stripTestSelectors) {
     assert.equal(find('.test6').find('div[data-non-test]').length, 0, 'data-non-test does not exists');
   });
 
-  if (GTE_EMBER_1_13) {
-    test('it binds data-test-* attributes with boolean values on components', function(assert) {
-      assert.equal(find('.test7').find('div[data-test-with-boolean-value]').length, 1, 'data-test-with-boolean-value exists');
-    });
+  test('it binds data-test-* attributes with boolean values on components', function(assert) {
+    assert.equal(find('.test7').find('div[data-test-with-boolean-value]').length, 1, 'data-test-with-boolean-value exists');
+  });
 
-    test('it binds data-test-* attributes without values on components', function(assert) {
-      assert.equal(find('.test8').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
-    });
+  test('it binds data-test-* attributes without values on components', function(assert) {
+    assert.equal(find('.test8').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
 
-    test('it binds data-test-* attributes without values on block components', function(assert) {
-      assert.equal(find('.test9').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
-    });
+  test('it binds data-test-* attributes without values on block components', function(assert) {
+    assert.equal(find('.test9').find('div[data-test-without-value]').length, 1, 'data-test-without-value exists');
+  });
 
-    test('it leaves data-test attribute without value untouched on components', function(assert) {
-      assert.equal(find('.test10').find('div[data-test]').length, 0, 'data-test does not exists');
-    });
+  (hasPositionalParams ? test : skip)('it leaves data-test attribute without value untouched on components', function(assert) {
+    assert.equal(find('.test10').find('div[data-test]').length, 0, 'data-test does not exists');
+  });
 
-    test('it transforms data-test params to hash pairs on components', function(assert) {
-      assert.equal(find('.test11').find('div[data-test-something]').length, 1, 'data-test-something exists');
-    });
-  }
+  test('it transforms data-test params to hash pairs on components', function(assert) {
+    assert.equal(find('.test11').find('div[data-test-something]').length, 1, 'data-test-something exists');
+  });
 }

--- a/tests/dummy/app/controllers/bind-test.js
+++ b/tests/dummy/app/controllers/bind-test.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
+import { hasPositionalParams } from 'dummy/version-checks';
 
 const { Controller } = Ember;
 
 export default Controller.extend({
-  shouldRenderParamTests: GTE_EMBER_1_13
+  hasPositionalParams,
 });

--- a/tests/dummy/app/templates/bind-test.hbs
+++ b/tests/dummy/app/templates/bind-test.hbs
@@ -12,12 +12,12 @@
 
 <div class="test7">{{data-test-component data-test-with-boolean-value=true}}</div>
 
-{{#if shouldRenderParamTests}}
-  <div class="test8">{{data-test-component data-test-without-value}}</div>
+<div class="test8">{{data-test-component data-test-without-value}}</div>
 
-  <div class="test9">{{#data-test-component data-test-without-value}}foo{{/data-test-component}}</div>
+<div class="test9">{{#data-test-component data-test-without-value}}foo{{/data-test-component}}</div>
 
+{{#if hasPositionalParams}}
   <div class="test10">{{data-test-component data-test}}</div>
-
-  <div class="test11">{{data-test-component data-test-something some-prop="prop"}}</div>
 {{/if}}
+
+<div class="test11">{{data-test-component data-test-something some-prop="prop"}}</div>

--- a/tests/dummy/app/version-checks.js
+++ b/tests/dummy/app/version-checks.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 
 const { VERSION } = Ember;
 
+const EMBERS_WITHOUT_POSITIONAL_PARAMS = [
+  '1.12',
+  '1.11',
+];
+
 const EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS = [
   '2.2',
   '2.1',
@@ -10,6 +15,9 @@ const EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS = [
   '1.12',
   '1.11',
 ];
+
+export const hasPositionalParams = !EMBERS_WITHOUT_POSITIONAL_PARAMS
+  .some(version => VERSION.indexOf(`${version}.`) === 0);
 
 export const hasReliablePositionalParams = !EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS
   .some(version => VERSION.indexOf(`${version}.`) === 0);

--- a/tests/dummy/app/version-checks.js
+++ b/tests/dummy/app/version-checks.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+const { VERSION } = Ember;
+
+const EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS = [
+  '2.2',
+  '2.1',
+  '2.0',
+  '1.13',
+  '1.12',
+  '1.11',
+];
+
+export const hasReliablePositionalParams = !EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS
+  .some(version => VERSION.indexOf(`${version}.`) === 0);

--- a/tests/integration/strip-data-test-attributes-from-components-test.js
+++ b/tests/integration/strip-data-test-attributes-from-components-test.js
@@ -1,26 +1,12 @@
 import { moduleForComponent, test, skip } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 
 import config from 'dummy/config/environment';
+import { hasReliablePositionalParams } from 'dummy/version-checks';
 
 moduleForComponent('print-test-attributes', 'StripTestSelectorsTransform plugin', {
   integration: true
 });
-
-const { VERSION } = Ember;
-
-const EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS = [
-  '2.2',
-  '2.1',
-  '2.0',
-  '1.13',
-  '1.12',
-  '1.11',
-];
-
-const hasReliablePositionalParams = !EMBERS_WITHOUT_RELIABLE_POSITIONAL_PARAMS
-  .some(version => VERSION.indexOf(`${version}.`) === 0);
 
 if (config.stripTestSelectors) {
 

--- a/transform-test-selector-params-to-hash-pairs.js
+++ b/transform-test-selector-params-to-hash-pairs.js
@@ -19,6 +19,10 @@ TransformTestSelectorParamsToHashPairs.prototype.transform = function(ast) {
 
   walker.visit(ast, function(node) {
     if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+      if ('sexpr' in node) {
+        node = node.sexpr;
+      }
+
       let testSelectorParams = [];
       let otherParams = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,14 +1969,6 @@ ember-cli@~2.16.1:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
-ember-compatibility-helpers@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.2.tgz#8eb1769ad761db273fd40242b1170d9f3841d0f0"
-  dependencies:
-    babel-plugin-debug-macros "^0.1.11"
-    ember-cli-version-checker "^2.0.0"
-    semver "^5.4.1"
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.2.tgz#261cccaf6bf8fbb1836be7bdfe4278f9ab92b873"
@@ -4361,10 +4353,6 @@ sane@^1.1.1, sane@^1.6.0:
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
This PR also reenables the actual attribute stripping transform which was apparently disabled by mistake in https://github.com/simplabs/ember-test-selectors/pull/150.

/cc @pzuraq @marcoow @geekygrappler 