### PR TITLE
Use `assert()` for "read-only attributeBindings" warning

### DIFF
--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -1,4 +1,4 @@
-import { assert, warn } from '@ember/debug';
+import { assert } from '@ember/debug';
 import { isArray } from '@ember/array';
 
 const TEST_SELECTOR_PREFIX = /data-test-.*/;
@@ -40,7 +40,7 @@ export default function bindDataTestAttributes(component) {
     let message = `ember-test-selectors could not bind data-test-* properties on ${component} ` +
       `automatically because "attributeBindings" is a read-only property.`;
 
-    warn(message, false, {
+    assert(message, false, {
       id: 'ember-test-selectors.computed-attribute-bindings',
     });
   }

--- a/tests/unit/utils/bind-data-test-attributes-test.js
+++ b/tests/unit/utils/bind-data-test-attributes-test.js
@@ -96,7 +96,7 @@ test('it does not add a data-test property', function(assert) {
   assert.deepEqual(instance.get('attributeBindings'), undefined);
 });
 
-test('it skips if attributeBindings is a computed property', function(assert) {
+test('it breaks if attributeBindings is a computed property', function(assert) {
   let Fixture = EmberObject.extend({
     attributeBindings: computed('prop', function() {
       return [this.get('prop')];
@@ -112,11 +112,7 @@ test('it skips if attributeBindings is a computed property', function(assert) {
     'data-test-from-invocation': 'bar',
   });
 
-  assert.deepEqual(instance.get('attributeBindings'), ['foo']);
-
-  bindDataTestAttributes(instance);
-
-  assert.deepEqual(instance.get('attributeBindings'), ['foo']);
+  assert.throws(() => bindDataTestAttributes(instance));
 });
 
 test('it breaks if tagName is empty', function(assert) {


### PR DESCRIPTION
This is similar to https://github.com/simplabs/ember-test-selectors/pull/205 and makes the warnings/error more consistent.

I'm marking this as a breaking change because it might cause previously succeeding builds to fail now. If the component has no `data-test-` properties everything should still work fine though.