### PR TITLE
Drop support for Node.js 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,6 @@ jobs:
   - <<: *node-test
     node_js: 8
 
-  - <<: *node-test
-    node_js: 6
-
 
 deploy:
   provider: npm

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qunit-dom": "^0.8.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "8.* || >= 10.*"
   },
   "changelog": {
     "repo": "simplabs/ember-test-selectors",


### PR DESCRIPTION
Node 4 ist EOL and Node 6 will follow at the end of the month. Since we have several other breaking changes queued up, I think it is time to drop support for these old Node releases.