### PR TITLE
Use `setupPreprocessorRegistry()` hook to register HTMLBars AST plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ More information on why that is useful are available on our
 [![ember-test-selectors](https://cloud.githubusercontent.com/assets/2922250/25236119/0cc8e13a-25b5-11e7-8a5b-f29589384833.png)
 ](https://embermap.com/video/ember-test-selectors)
 
+
+Compatibility
+------------------------------------------------------------------------------
+
+- Ember CLI 2.14 or above
+
+
 Installation
 ------------------------------------------------------------------------------
 

--- a/index.js
+++ b/index.js
@@ -26,38 +26,34 @@ module.exports = {
     }
   },
 
-  _setupPreprocessorRegistry(registry) {
-    if (this._stripTestSelectors) {
-      let StripTestSelectorsTransform = require('./strip-test-selectors');
+  setupPreprocessorRegistry(type, registry) {
+    if (type === 'parent') {
+      this._assignOptions(this.app);
 
-      registry.add('htmlbars-ast-plugin', {
-        name: 'strip-test-selectors',
-        plugin: StripTestSelectorsTransform,
-        baseDir() { return __dirname; },
-        cacheKey() { return 'strip-test-selectors'; },
-      });
-    } else {
-      let TransformTestSelectorParamsToHashPairs = require('./transform-test-selector-params-to-hash-pairs');
+      if (this._stripTestSelectors) {
+        let StripTestSelectorsTransform = require('./strip-test-selectors');
 
-      registry.add('htmlbars-ast-plugin', {
-        name: 'transform-test-selector-params-to-hash-pairs',
-        plugin: TransformTestSelectorParamsToHashPairs,
-        baseDir() { return __dirname; },
-        cacheKey() { return 'transform-test-selector-params-to-hash-pairs'; },
-      });
+        registry.add('htmlbars-ast-plugin', {
+          name: 'strip-test-selectors',
+          plugin: StripTestSelectorsTransform,
+          baseDir() { return __dirname; },
+          cacheKey() { return 'strip-test-selectors'; },
+        });
+      } else {
+        let TransformTestSelectorParamsToHashPairs = require('./transform-test-selector-params-to-hash-pairs');
+
+        registry.add('htmlbars-ast-plugin', {
+          name: 'transform-test-selector-params-to-hash-pairs',
+          plugin: TransformTestSelectorParamsToHashPairs,
+          baseDir() { return __dirname; },
+          cacheKey() { return 'transform-test-selector-params-to-hash-pairs'; },
+        });
+      }
     }
   },
 
   included(app) {
     this._super.included.apply(this, arguments);
-    this._ensureFindHost();
-
-    let host = this._findHost();
-    this._assignOptions(host);
-
-    // we can't use the setupPreprocessorRegistry() hook as it is called to
-    // early and we do not have reliable access to `app.tests` there yet
-    this._setupPreprocessorRegistry(app.registry);
 
     // add the StripDataTestPropertiesPlugin to the list of plugins used by
     // the `ember-cli-babel` addon
@@ -83,7 +79,7 @@ module.exports = {
     }
 
     if (!this._stripTestSelectors) {
-      host.import('vendor/ember-test-selectors/patch-component.js');
+      this.app.import('vendor/ember-test-selectors/patch-component.js');
     }
   },
 
@@ -102,18 +98,5 @@ module.exports = {
       tree = require('broccoli-stew').rm(tree, 'dummy/tests/unit/**/*.js');
     }
     return tree;
-  },
-
-  _ensureFindHost() {
-    if (!this._findHost) {
-      this._findHost = function findHostShim() {
-        let current = this;
-        let app;
-        do {
-          app = current.app || app;
-        } while (current.parent.parent && (current = current.parent));
-        return app;
-      };
-    }
   },
 };


### PR DESCRIPTION
In Ember CLI 2.14 the `setupPreprocessorRegistry()` hook gained access to `this.app`, which means we can finally register our AST plugin properly

This should be considered a breaking change as it raises the minimum Ember CLI version to 2.14.

Resolves #333