### PR TITLE
Adjust Ember.js support range to 2.16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ More information on why that is useful are available on our
 Compatibility
 ------------------------------------------------------------------------------
 
+- Ember 2.16 or above
 - Ember CLI 2.14 or above
 
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=1.11"
+      "ember": ">=2.12"
     }
   },
   "greenkeeper": {


### PR DESCRIPTION
This should significantly speed up our CI times and users on older Ember versions can still use older releases of this addon