### PR TITLE
testem: Increase `browser_start_timeout`

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -8,6 +8,7 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       mode: 'ci',


### PR DESCRIPTION
... for GitHub Actions 😕

This will hopefully resolve the timeouts we've been seeing occasionally.