### PR TITLE
Drop support for Node 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qunit-dom": "^0.9.1"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "changelog": {
     "repo": "simplabs/ember-test-selectors",


### PR DESCRIPTION
Node 8 is no longer supported by the Node developers, so we should drop support too. This will unblock a few of the open dependency upgrade PRs.