### PR TITLE
Drop support for Ember releases before v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=2.12"
+      "ember": ">=3"
     }
   },
   "greenkeeper": {


### PR DESCRIPTION
mostly to cut down our CI time... 😅 