### PR TITLE
Ensure test selector stripping works for inline template compilation and co-located components

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     }
   },
   "ember-addon": {
+    "before": [
+      "ember-cli-htmlbars",
+      "ember-cli-htmlbars-inline-precompile"
+    ],
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
       "ember": ">=3"


### PR DESCRIPTION
Prior to this, the `registry.add('htmlbars-ast-plugin', ...)` invocation in `index.js` runs _after_ all of the `htmlbars-ast-plugins` are read and registered for inline JS/TS compilation. It is still before stand alone templates are ran (and that is why it works for `*.hbs` files that are not colocation).

This ensures that `ember-test-selectors` runs _before_ `ember-cli-htmlbars` / `ember-cli-htmlbars-inline-precompile (so that we can ensure that `ember-test-selectors` included runs, and therefore the `htmlbars-ast-plugin` is registered before it is needed for inline template compilation).

Fixes #427