### PR TITLE
bind-data-test-attributes: Avoid deprecated `getWithDefault()` call

### DIFF
--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -30,7 +30,7 @@ export default function bindDataTestAttributes(component) {
     id: 'ember-test-selectors.empty-tag-name',
   });
 
-  let attributeBindings = component.getWithDefault('attributeBindings', []);
+  let attributeBindings = component.get('attributeBindings') || [];
   if (!isArray(attributeBindings)) {
     attributeBindings = [attributeBindings];
   } else {


### PR DESCRIPTION
see http://emberjs.github.io/rfcs/0554-deprecate-getwithdefault.html