### PR TITLE
Convert class based template compilation plugin to functional style

### DIFF
--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -8,6 +8,20 @@ function isTestSelector(attribute) {
   return TEST_SELECTOR_PREFIX.test(attribute);
 }
 
+function stripTestSelectors(node) {
+  if ('sexpr' in node) {
+    node = node.sexpr;
+  }
+
+  node.params = node.params.filter(function(param) {
+    return !isTestSelector(param.original);
+  });
+
+  node.hash.pairs = node.hash.pairs.filter(function(pair) {
+    return !isTestSelector(pair.key);
+  });
+}
+
 function StripTestSelectorsTransform() {
   this.syntax = null;
 }
@@ -21,17 +35,7 @@ StripTestSelectorsTransform.prototype.transform = function(ast) {
         return !isTestSelector(attribute.name);
       });
     } else if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
-      if ('sexpr' in node) {
-        node = node.sexpr;
-      }
-
-      node.params = node.params.filter(function(param) {
-        return !isTestSelector(param.original);
-      });
-
-      node.hash.pairs = node.hash.pairs.filter(function(pair) {
-        return !isTestSelector(pair.key);
-      });
+      stripTestSelectors(node);
     }
   });
 

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -9,10 +9,6 @@ function isTestSelector(attribute) {
 }
 
 function stripTestSelectors(node) {
-  if ('sexpr' in node) {
-    node = node.sexpr;
-  }
-
   node.params = node.params.filter(function(param) {
     return !isTestSelector(param.original);
   });

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -27,16 +27,22 @@ function StripTestSelectorsTransform() {
 }
 
 StripTestSelectorsTransform.prototype.transform = function(ast) {
-  let walker = new this.syntax.Walker();
+  let { traverse } = this.syntax;
 
-  walker.visit(ast, function(node) {
-    if (node.type === 'ElementNode') {
+  traverse(ast, {
+    ElementNode(node) {
       node.attributes = node.attributes.filter(function(attribute) {
         return !isTestSelector(attribute.name);
       });
-    } else if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+    },
+
+    MustacheStatement(node) {
       stripTestSelectors(node);
-    }
+    },
+
+    BlockStatement(node) {
+      stripTestSelectors(node);
+    },
   });
 
   return ast;

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -8,11 +8,6 @@ function isTestSelector(attribute) {
   return TEST_SELECTOR_PREFIX.test(attribute);
 }
 
-function stripTestSelectors(node) {
-  node.params = node.params.filter(param => !isTestSelector(param.original));
-  node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
-}
-
 function transform() {
   return {
     name: 'strip-test-selectors',
@@ -23,11 +18,13 @@ function transform() {
       },
 
       MustacheStatement(node) {
-        stripTestSelectors(node);
+        node.params = node.params.filter(param => !isTestSelector(param.original));
+        node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
       },
 
       BlockStatement(node) {
-        stripTestSelectors(node);
+        node.params = node.params.filter(param => !isTestSelector(param.original));
+        node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
       },
     }
   };

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -9,13 +9,8 @@ function isTestSelector(attribute) {
 }
 
 function stripTestSelectors(node) {
-  node.params = node.params.filter(function(param) {
-    return !isTestSelector(param.original);
-  });
-
-  node.hash.pairs = node.hash.pairs.filter(function(pair) {
-    return !isTestSelector(pair.key);
-  });
+  node.params = node.params.filter(param => !isTestSelector(param.original));
+  node.hash.pairs = node.hash.pairs.filter(pair => !isTestSelector(pair.key));
 }
 
 function transform() {
@@ -24,9 +19,7 @@ function transform() {
 
     visitor: {
       ElementNode(node) {
-        node.attributes = node.attributes.filter(function(attribute) {
-          return !isTestSelector(attribute.name);
-        });
+        node.attributes = node.attributes.filter(attribute => !isTestSelector(attribute.name));
       },
 
       MustacheStatement(node) {

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -18,30 +18,26 @@ function stripTestSelectors(node) {
   });
 }
 
-function StripTestSelectorsTransform() {
-  this.syntax = null;
+function transform() {
+  return {
+    name: 'strip-test-selectors',
+
+    visitor: {
+      ElementNode(node) {
+        node.attributes = node.attributes.filter(function(attribute) {
+          return !isTestSelector(attribute.name);
+        });
+      },
+
+      MustacheStatement(node) {
+        stripTestSelectors(node);
+      },
+
+      BlockStatement(node) {
+        stripTestSelectors(node);
+      },
+    }
+  };
 }
 
-StripTestSelectorsTransform.prototype.transform = function(ast) {
-  let { traverse } = this.syntax;
-
-  traverse(ast, {
-    ElementNode(node) {
-      node.attributes = node.attributes.filter(function(attribute) {
-        return !isTestSelector(attribute.name);
-      });
-    },
-
-    MustacheStatement(node) {
-      stripTestSelectors(node);
-    },
-
-    BlockStatement(node) {
-      stripTestSelectors(node);
-    },
-  });
-
-  return ast;
-};
-
-module.exports = StripTestSelectorsTransform;
+module.exports = transform;

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -8,7 +8,7 @@ function isTestSelector(attribute) {
   return TEST_SELECTOR_PREFIX.test(attribute);
 }
 
-function transform() {
+module.exports = function() {
   return {
     name: 'strip-test-selectors',
 
@@ -28,6 +28,4 @@ function transform() {
       },
     }
   };
-}
-
-module.exports = transform;
+};


### PR DESCRIPTION
This PR addresses https://github.com/emberjs/ember.js/pull/19429 and should hopefully fix https://github.com/simplabs/ember-test-selectors/issues/671.

In other words, this should fix the deprecation message that started popping up on Ember v3.27.