### PR TITLE
dummy: Add missing `this.` prefixes

### DIFF
--- a/tests/dummy/app/templates/components/print-test-attributes.hbs
+++ b/tests/dummy/app/templates/components/print-test-attributes.hbs
@@ -1,5 +1,5 @@
-<div class="data-test-first">{{data-test-first}}</div>
-<div class="data-test-second">{{data-test-second}}</div>
-<div class="data-non-test">{{data-non-test}}</div>
-<div class="data-test">{{data-test}}</div>
-<div class="data-test-positional-params">{{params.length}}</div>
+<div class="data-test-first">{{this.data-test-first}}</div>
+<div class="data-test-second">{{this.data-test-second}}</div>
+<div class="data-non-test">{{this.data-non-test}}</div>
+<div class="data-test">{{this.data-test}}</div>
+<div class="data-test-positional-params">{{this.params.length}}</div>


### PR DESCRIPTION
... to fix the corresponding deprecation warnings