### PR TITLE
Deprecate automatic attribute bindings

### DIFF
--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { isArray } from '@ember/array';
 
 const TEST_SELECTOR_PREFIX = /data-test-.*/;
@@ -39,6 +39,16 @@ export default function bindDataTestAttributes(component) {
 
   for (let prop of dataTestProperties) {
     if (attributeBindings.indexOf(prop) === -1) {
+      let componentName = extractComponentName(component) || `<unknown>`;
+      deprecate(`You have set ${prop} on the ${componentName} component. Relying on automatic attribute binding of data-test properties on classic components is deprecated. Your options are:\n\n` +
+        '- use angle bracket syntax with `...attributes` to invoke components\n' +
+        '- explicitly add `attributeBindings` to the component\n' +
+        '- stay on an older version of ember-test-selectors\n\n', false, {
+        for: 'ember-test-selectors',
+        id: 'ember-test-selectors.auto-binding',
+        until: '6.0.0',
+        since: { available: '5.2.0', enabled: '5.2.0' },
+      });
       attributeBindings.push(prop);
     }
   }
@@ -53,5 +63,17 @@ export default function bindDataTestAttributes(component) {
     assert(message, false, {
       id: 'ember-test-selectors.computed-attribute-bindings',
     });
+  }
+}
+
+function extractComponentName(component) {
+  let debugKey = component._debugContainerKey;
+  if (debugKey) {
+    return debugKey.replace(/^component:/, '');
+  }
+
+  let className = component.constructor.name;
+  if (className && className !== 'Class') {
+    return className;
   }
 }

--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -37,7 +37,9 @@ export default function bindDataTestAttributes(component) {
     attributeBindings = attributeBindings.slice();
   }
 
-  dataTestProperties.forEach(it => attributeBindings.push(it));
+  for (let prop of dataTestProperties) {
+    attributeBindings.push(prop);
+  }
 
   try {
     component.set('attributeBindings', attributeBindings);

--- a/addon/utils/bind-data-test-attributes.js
+++ b/addon/utils/bind-data-test-attributes.js
@@ -38,7 +38,9 @@ export default function bindDataTestAttributes(component) {
   }
 
   for (let prop of dataTestProperties) {
-    attributeBindings.push(prop);
+    if (attributeBindings.indexOf(prop) === -1) {
+      attributeBindings.push(prop);
+    }
   }
 
   try {


### PR DESCRIPTION
https://github.com/simplabs/ember-test-selectors/issues/709 leaves us basically no other choice but to deprecate this functionality. Since Classic components in Ember and the curly invocation syntax are essentially deprecated and many apps have moved on to using Angle Bracket syntax this functionality is not really needed anymore and removing it should not break too many apps.