### PR TITLE
Add `patchClassicComponent` option to avoid deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ module.exports = {
     } else {
       this._stripTestSelectors = !app.tests;
     }
+
+    this._shouldPatchClassicComponent = !this._stripTestSelectors && addonOptions.patchClassicComponent !== false;
   },
 
   _setupPreprocessorRegistry(registry) {
@@ -73,7 +75,7 @@ module.exports = {
       this._registeredWithBabel = true;
     }
 
-    if (!this._stripTestSelectors) {
+    if (this._shouldPatchClassicComponent) {
       host.import('vendor/ember-test-selectors/patch-component.js');
     }
   },
@@ -89,7 +91,7 @@ module.exports = {
 
   treeForAddon() {
     // remove our "addon" folder from the build if we're stripping test selectors
-    if (!this._stripTestSelectors) {
+    if (this._shouldPatchClassicComponent) {
       return this._super.treeForAddon.apply(this, arguments);
     }
   },


### PR DESCRIPTION
To opt-in to address https://github.com/simplabs/ember-test-selectors/issues/709 until a breaking release is made.

This would allow you to specify:

```js
  let app = new EmberAddon(defaults, {
    'ember-test-selectors': {
      patchClassicComponent: false
    }
  });
```

To avoid including the patch at all, thus avoid the deprecations if you do not use classic components (or the bindings on classic components, at least).