### PR TITLE
Fix caching warnings when running under Embroider

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,8 +112,8 @@ module.exports = {
     return {
       name: 'strip-test-selectors',
       plugin: StripTestSelectorsTransform,
-      baseDir() { return __dirname; },
-      cacheKey() { return 'strip-test-selectors'; },
+      baseDir: StripTestSelectorsTransform.baseDir,
+      cacheKey: StripTestSelectorsTransform.cacheKey,
     };
   },
 
@@ -123,8 +123,8 @@ module.exports = {
     return {
       name: 'transform-test-selector-params-to-hash-pairs',
       plugin: TransformTestSelectorParamsToHashPairs,
-      baseDir() { return __dirname; },
-      cacheKey() { return 'transform-test-selector-params-to-hash-pairs'; },
+      baseDir: TransformTestSelectorParamsToHashPairs.baseDir,
+      cacheKey: TransformTestSelectorParamsToHashPairs.cacheKey,
     };
   },
 };

--- a/strip-test-selectors.js
+++ b/strip-test-selectors.js
@@ -29,3 +29,11 @@ module.exports = function() {
     }
   };
 };
+
+module.exports.baseDir = function() {
+  return __dirname;
+};
+
+module.exports.cacheKey = function() {
+  return 'strip-test-selectors';
+};

--- a/transform-test-selector-params-to-hash-pairs.js
+++ b/transform-test-selector-params-to-hash-pairs.js
@@ -44,3 +44,11 @@ module.exports = function(env) {
     },
   };
 };
+
+module.exports.baseDir = function() {
+  return __dirname;
+};
+
+module.exports.cacheKey = function() {
+  return 'transform-test-selector-params-to-hash-pairs';
+};


### PR DESCRIPTION
Prior to this change, you would receive the following warnings during an Embroider build:

```
broccoli-babel-transpiler is opting out of caching due to a plugin that does not provide a caching strategy: `function(env) {
  let b = env.syntax.builders;
  let transform = (node) => {
    if ('sexpr' in node) {
      node = node.sexpr;
    }

    let testSelectorParams = [];
    let otherParams = [];

    node.params.forEach(function(param) {
      if (isTestSelectorParam(param)) {
        testSelectorParams.push(param);
      } else {
        otherParams.push(param);
      }
    });

    node.params = otherParams;

    testSelectorParams.forEach(function(param) {
      let pair = b.pair(param.original, b.boolean(true));
      node.hash.pairs.push(pair);
    });
  };

  return {
    name: 'TransformTestSelectorParamsToHashPairs',

    visitor: {
      MustacheStatement: transform,
      BlockStatement: transform,
    },
  };
}`
```

The reason for this warning is that Embroider is attempting to read the caching information (baseDir and cacheKey) from the plugin itself (not the wrapper we register). Some recent changes in Embroider have improved things a bit (reducing the number of cases where this warning will occur), but fixing all scenarios is quite difficult.

---

This PR works around the issue by placing the caching information on both the registries wrapper object **and** the plugin itself (ensuring that there is still a single source of truth).

This fixes the warning you get when running in Embroider builds.
