### PR TITLE
Deprecate ember-cli-babel v5.x support

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ module.exports = {
         appOrParent.options.babel = appOrParent.options.babel || {};
         appOrParent.options.babel.plugins = appOrParent.options.babel.plugins || [];
         appOrParent.options.babel.plugins.push(require('./strip-data-test-properties-plugin'));
+
+        this.ui.writeWarnLine('[ember-test-selectors] DEPRECATION: Using ember-cli-babel v5 with ember-test-selectors ' +
+          'is deprecated. Please make sure to update your ember-cli-babel version.');
       } else if (checker.satisfies('^6.0.0-beta.1') || checker.satisfies('^7.0.0')) {
         appOrParent.options.babel6 = appOrParent.options.babel6 || {};
         appOrParent.options.babel6.plugins = appOrParent.options.babel6.plugins || [];


### PR DESCRIPTION
Even ember-cli-babel v6.x is not officially supported anymore by the ember-cli team, so dropping support for ember-cli-babel v5.x should be uncontroversial. Dropping support will allow us to simplify our testing setup quite a bit.