### PR TITLE
Remove obsolete `greenkeeper` configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,12 +81,5 @@
     "versionCompatibility": {
       "ember": ">=3.8"
     }
-  },
-  "greenkeeper": {
-    "ignore": [
-      "babel-core",
-      "eslint-plugin-ember",
-      "eslint-plugin-qunit"
-    ]
   }
 }


### PR DESCRIPTION
We're using https://github.com/renovatebot/renovate these days :)