### PR TITLE
Stop testing on non-LTS Ember releases before v3.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ],
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=3.8"
+      "ember": "3.8 || 3.12 || 3.16 || 3.20 || >=3.24"
     }
   }
 }


### PR DESCRIPTION
Using the addon with these Ember versions most likely still continues to work, but since we're dropping support I'm marking this as a breaking change too.